### PR TITLE
AL-91 Bugfix Dimension of outputs updated

### DIFF
--- a/nutrients_predictor/nn_predictor.py
+++ b/nutrients_predictor/nn_predictor.py
@@ -139,6 +139,7 @@ class TrainingPipeline:
                 inputs, targets = inputs.to(self.device), targets.to(self.device)
                 optimizer.zero_grad()
                 outputs = self.model(inputs)
+                outputs = outputs.view(-1)
                 loss = self.criterion(outputs, targets)
                 loss.backward()
                 optimizer.step()
@@ -156,6 +157,7 @@ class TrainingPipeline:
             for inputs, targets in self.test_loader:
                 inputs, targets = inputs.to(self.device), targets.to(self.device)
                 outputs = self.model(inputs)
+                outputs = outputs.view(-1)
                 loss = self.criterion(outputs, targets)
                 test_loss += loss.item()
         print(f"Test Loss: {test_loss / len(self.test_loader):.4f}")


### PR DESCRIPTION
### Ticket:

* AL-91

### Description/Motivation:

- Dimension of "outputs" compared to "targets" differed, this caused a waring message during training


### What did I do:

- Bugfix: Dimension of "outputs" adapted to fit the dimension of "targets"


### How did I test my change:

- Debugging
- Warning message disappeared

## Version change

Please check the type of change your PR introduces:

- [ ] Major (Interface changes, other branches/tickets may be affected)
- [ ] Minor (New functionality in a backwards compatible manner)
- [x] Patch (Backward compatible bug fixes)

## Checklist

- [x] Code has been tested and works correctly.
- [x] [Git/Coding Conventions](https://agrolens.atlassian.net/wiki/spaces/AgroLensSp/pages/19300405/Git+Coding+Conventions) were taken into account.
- [x] Branch and PR are correctly named to reference the corresponding issue in JIRA (AL-000).
- [ ] Extended the README / documentation in Confluence, if necessary
- [ ] All GitHub checks and workflows pass.
