### PR TITLE
AL-126 load models to make prediction

### DIFF
--- a/nutrients_predictor/make_prediction.py
+++ b/nutrients_predictor/make_prediction.py
@@ -10,8 +10,8 @@ def main():
     model_config = 'Model_A'   # Select model (Differs in the used feature columns)
 
     # Select target nutrient 'pH_CaCl2', 'pH_H2O', 'P', 'N', 'K'
-    target = 'pH_H2O'
-    path_loadmodel = f"/media/data/Models/{model_config}/{model_var}/{model_config}_{model_var}_{target}.json"
+    target = 'N'
+    path_loadmodel = f"/media/data/Models/{model_config}/{model_var}/{model_config}_{model_var}_{target}"
 
     # Feature columns
     if model_config == 'Model_A':
@@ -22,48 +22,49 @@ def main():
         feature_columns = [] #tbd
 
     # Input data for predicition
-    file_path = '/media/data/Datasets/Model_A_Soil+Sentinel_norm.csv'
+    file_path = '/media/data/Datasets/Model_A_Soil+Sentinel_norm.csv'   # Update needed!
 
-    # Read CSV
+    # Input data for prediction
     data = pd.read_csv(file_path)
     input_data = data[feature_columns]
     target_data = data[target]
 
     print(f'-----Prediction of {target} with {model_config} {model_var}-----')
+
     if model_var == 'xgboost':
-        # Load xgboost and make prediciton
         model = xgb.Booster()
-        model.load_model(path_loadmodel)
+        model.load_model(f'{path_loadmodel}.json')
 
         # Datatype change
         dinput_data = xgb.DMatrix(input_data)
 
-        # Vorhersagen für den gesamten Datensatz machen
+        # XGBoost predicitions
         predictions = model.predict(dinput_data)
 
-        # RMSE-Fehler berechnen
         mse_error = mean_squared_error(target_data, predictions)
         rmse_error = np.sqrt(mse_error)
 
     elif model_var == 'nn':
-        print()
+        print("NN logic not implemented yet.")
 
     elif model_var == 'rf':
-        print()
+        print("RF logic not implemented yet.")
 
+    # Add predictions and errors to DataFrame
+    data['Target'] = target_data
+    data['Prediction'] = predictions
+    data['Error'] = (data['Prediction'] - data[target])  # Fehler (quadratische Abweichung)
 
-
-
-    # Vorhersagen und Fehler zum DataFrame hinzufügen
-    data['prediction'] = predictions
-    data['RMSE'] = (data['prediction'] - data[target]) ** 2  # Fehler (quadratische Abweichung)
-
-    # Ergebnisse anzeigen
+    # Results
     print(f"Root Mean Squared Error (RMSE): {rmse_error:.4f}")
     print(data[['norm_B01', 'norm_B02', 'norm_B03', 'norm_B04', 
                 'norm_B05', 'norm_B06', 'norm_B07', 'norm_B08', 
                 'norm_B8A', 'norm_B09', 'norm_B11', 'norm_B12', 
-                'prediction', 'RMSE']])
+                'Target','Prediction', 'Error']])
+    
+    # output_file = f"/home/ubuntu/AgroLens/output/{model_config}_{model_var}_{target}_predictions.csv"
+    # data.to_csv(output_file, index=False)
+    # print(f"Predictions saved to {output_file}")
     
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Ticket:

* AL-126

### Description/Motivation:

-  Models can be trained and saved, but currently the saved models can not be used to make a nutrient prediciton by entering any input.

### What did I do:

- New script make_prediction which makes a nutrient prediction based on the selected model variant and model config and the given input
- Currently only predictions for the xgboost can be make with this script. Implementation for nn and rf is prepared.
- Note: Currently as input data the trainings data file is given, this need to be updated with a validation data file.

### How did I test my change:

- CSV with predictions was generated and checked.


## Version change

Please check the type of change your PR introduces:

- [x] Major (Interface changes, other branches/tickets may be affected)
- [x] Minor (New functionality in a backwards compatible manner)
- [ ] Patch (Backward compatible bug fixes)

## Checklist

- [x] Code has been tested and works correctly.
- [x] [Git/Coding Conventions](https://agrolens.atlassian.net/wiki/spaces/AgroLensSp/pages/19300405/Git+Coding+Conventions) were taken into account.
- [x] Branch and PR are correctly named to reference the corresponding issue in JIRA (AL-000).
- [ ] Extended the README / documentation in Confluence, if necessary
- [ ] All GitHub checks and workflows pass.
